### PR TITLE
Fix changeBackgroundColor function to use a consistent default bg-color

### DIFF
--- a/app/libs/utils.js
+++ b/app/libs/utils.js
@@ -71,7 +71,7 @@ const isValidData = async (table, data) => {
 const changeBackgroundColor = (type) => {
   const color = type === "success" ? "lightgreen" : "lightcoral";
 
-  const originalBackgroundColor = document.body.style.backgroundColor;
+  const originalBackgroundColor = "#fff"; 
   document.body.style.backgroundColor = color;
   setTimeout(() => {
     document.body.style.backgroundColor = originalBackgroundColor;


### PR DESCRIPTION
This pull request makes a minor update to the background color reset logic in the `changeBackgroundColor` function. Instead of restoring the previous background color from the DOM, it now resets it to a default value.

* The `originalBackgroundColor` variable in `changeBackgroundColor` is set to `"#fff"` (white) instead of reading the current value from `document.body.style.backgroundColor`.